### PR TITLE
add options.cwd to set current working directory for command

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,11 @@ type: `Boolean`
 default: `false`
 
 By default, it will print the command output.
+
+#### options.cwd
+
+type: `String`
+
+default: Result of `process.cwd()` (as described [here](http://nodejs.org/api/process.html#process_process_cwd))
+
+Sets the current working directory for the command.

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ function shell(commands, options) {
   var separator = process.platform.match(/^win/) >= 0 ? ';' : ':'
   var path = pathToBin + separator + process.env.PATH
   var env = _.extend({}, process.env, {PATH: path})
+  var cwd = options.cwd || process.cwd()
 
   return through.obj(function (file, _, done) {
     var self = this
@@ -31,7 +32,7 @@ function shell(commands, options) {
     async.eachSeries(commands, function (command, done) {
       command = gutil.template(command, {file: file})
 
-      cp.exec(command, {env: env}, function (error, stdout, stderr) {
+      cp.exec(command, {env: env, cwd: cwd}, function (error, stdout, stderr) {
         if (!quiet) {
           if (stderr) gutil.log(stderr.trim())
           if (stdout) gutil.log(stdout.trim())

--- a/test/index.js
+++ b/test/index.js
@@ -113,5 +113,37 @@ describe('gulp-shell(commands, options)', function () {
         stream.write(fakeFile)
       })
     })
+
+    describe('cwd', function () {
+      it('should set the current working directory when `cwd` is a string', function (done) {
+        var stream = shell(['pwd'], {cwd: '..'})
+
+        var write = process.stdout.write
+        process.stdout.write = function (output) {
+          process.stdout.write = write
+          should(output).containEql(join(__dirname, '../..'))
+          should(output).not.containEql(join(__dirname, '..'))
+          done()
+        }
+
+        stream.write(fakeFile)
+      })
+    })
+
+    describe('cwd', function () {
+      it('should use the process current working directory when `cwd` is not passed', function (done) {
+        var stream = shell(['pwd'])
+
+        var write = process.stdout.write
+        process.stdout.write = function (output) {
+          process.stdout.write = write
+          should(output).containEql(join(__dirname, '..'))
+          done()
+        }
+
+        stream.write(fakeFile)
+      })
+    })
+
   })
 })


### PR DESCRIPTION
Adds the ability to set current working directory for command, handled the same was as Node's [`child_process`](http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback). Test included.
