### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ var gulp  = require('gulp')
 var shell = require('gulp-shell')
 
 gulp.task('example', function () {
-  return gulp.src('*.js')
+  return gulp.src('*.js', {read:false})
     .pipe(shell([
       'echo  <%= file.path %>',
       'ls -l <%= file.path %>'


### PR DESCRIPTION
Since you don't actually need the contents of the files, it'll be more efficient to set read:false on the gulp.src.
