### PR TITLE
Increase maxBuffer for exec command

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function shell(commands, options) {
     async.eachSeries(commands, function (command, done) {
       command = gutil.template(command, {file: file})
 
-      var child = exec(command, {env: env, cwd: options.cwd}, function (error) {
+      var child = exec(command, {env: env, cwd: options.cwd, maxBuffer: 16 * 1024 * 1024}, function (error) {
         done(options.ignoreErrors ? null : error)
       })
 


### PR DESCRIPTION
I get "Error: stdout maxBuffer exceeded" error while running a gulp task which outputs a little bigger stdout (compiling ios app). This will fix it.
