### PR TITLE
Explicitly kill the child process on exit if it hasn't completed

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,15 @@ function shell(commands, options) {
     async.eachSeries(commands, function (command, done) {
       command = gutil.template(command, {file: file})
 
+      var exitHandler = function (code) {
+        if (child) {
+          child.kill()
+        }
+      }
+      process.on('exit', exitHandler)
+
       var child = exec(command, {env: env, cwd: options.cwd, maxBuffer: 16 * 1024 * 1024}, function (error) {
+        process.removeListener('exit', exitHandler)
         done(options.ignoreErrors ? null : error)
       })
 


### PR DESCRIPTION
I have encountered an issue with gulp where a child process continues running
even after killing (Ctrl-C) the parent process running gulp. This is fixed by
explicitly calling `child.kill()` when the parent exits.
