### PR TITLE
Add stdout and stderr to the error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,9 +38,14 @@ function shell(commands, options) {
         env: env,
         cwd: options.cwd,
         maxBuffer: options.maxBuffer
-      }, function (error) {
+      }, function (error, stdout, stderr) {
         process.stdin.unpipe(child.stdin)
         process.stdin.pause()
+
+        if (error && !options.ignoreErrors) {
+          error.stdout = stdout
+          error.stderr = stderr
+        }
 
         done(options.ignoreErrors ? null : error)
       })
@@ -54,7 +59,10 @@ function shell(commands, options) {
       }
     }, function (error) {
       if (error) {
-        self.emit('error', new gutil.PluginError(PLUGIN_NAME, error))
+        self.emit('error', new gutil.PluginError(PLUGIN_NAME, error, {
+          stdout: error.stdout,
+          stderr: error.stderr
+        }))
       } else {
         self.push(file)
       }


### PR DESCRIPTION
The response is currently:

``` js
{ [Error: Command failed: ]
  killed: false,
  code: 1,
  signal: null,
  name: 'Error',
  message: 'Command failed: ',
  stack: 'Error: Command failed: \n    at ChildProcess.exithandler (child_process.js:647:15)\n    at ChildProcess.emit (events.js:98:17)\n    at maybeClose (child_process.js:755:16)\n    at Socket.<anonymous> (child_process.js:968:11)\n    at Socket.emit (events.js:95:17)\n    at Pipe.close (net.js:465:12)',
  showStack: false,
  showProperties: true,
  plugin: 'gulp-shell' }
```

It would be nice to have the `stdout` and the `stderr` to be able to display more information (or parse more information.) to get a better understanding about why this executable failed.
