### PR TITLE
Change error handling to be in the last handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function shell(commands, options) {
         env: env,
         cwd: options.cwd,
         maxBuffer: options.maxBuffer
-      }, function (error) {
+      }, function (error, stdout) {
         process.stdin.unpipe(child.stdin)
         process.stdin.pause()
 


### PR DESCRIPTION
Currently: the exec handler was getting all the data that checks against the flag `ignoreErrors`. If those errors are ignored, it's impossible to get them later on. 

This PR focuses on adding those messages to the file object, similar to how the jshint linter so they can be accessed later on. The returned file object has two additional attribute: 
- `error`: the error object.
- `stdout`: the console stdout.

Code wise you can do:

``` js
var pylint = shell(['something <%= file.path %>'],
    {quiet: true, ignoreErrors: true});

var onData = function(data) {
    console.log(data.stdout);
};

return gulp.src(config.pyFiles, {read: false})
    .pipe(pylint)
    .on('data', onData);
    });
```

Let me know if you have any question.
