### PR TITLE
Change error handling to be in the last handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,16 +38,14 @@ function shell(commands, options) {
         env: env,
         cwd: options.cwd,
         maxBuffer: options.maxBuffer
-      }, function (error, stdout, stderr) {
+      }, function (error, stdout) {
         process.stdin.unpipe(child.stdin)
         process.stdin.pause()
 
-        if (error && !options.ignoreErrors) {
-          error.stdout = stdout
-          error.stderr = stderr
-        }
-
-        done(options.ignoreErrors ? null : error)
+        done({
+          error: error,
+          stdout: stdout
+        })
       })
 
       process.stdin.resume()
@@ -57,13 +55,14 @@ function shell(commands, options) {
         child.stdout.pipe(process.stdout)
         child.stderr.pipe(process.stderr)
       }
-    }, function (error) {
-      if (error) {
-        self.emit('error', new gutil.PluginError(PLUGIN_NAME, error, {
-          stdout: error.stdout,
-          stderr: error.stderr
+    }, function (message) {
+      if (!options.ignoreErrors && message.error) {
+        self.emit('error', new gutil.PluginError(PLUGIN_NAME, message.error, {
+          stdout: message.stdout,
         }))
       } else {
+        file.error = message.error
+        file.stdout = message.stdout
         self.push(file)
       }
       done()


### PR DESCRIPTION
Currently: the exec handler was getting all the data that checks against the flag `ignoreErrors`. If those errors are ignored, it's impossible to get them later on.

This PR focuses on adding those messages to the file object, similar to how the jshint linter so they can be accessed later on. The returned file object has two additional attribute:
- `error`: the error object.
- `stdout`: the console stdout.

Code wise you can do:

``` js
var pylint = shell(['something <%= file.path %>'],
    {quiet: true, ignoreErrors: true});

var onData = function(data) {
    console.log(data.stdout);
};

return gulp.src(srcConf, {read: false})
    .pipe(pylint)
    .on('data', onData);
```

Let me know if you have any question.

@sun-zheng-an 
