### PR TITLE
Add clearEnv option

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,11 @@ You won't need to set this option unless you encounter a "stdout maxBuffer excee
 type: `Object`
 
 default: [`process.env`](http://nodejs.org/api/process.html#process_process_env) with `PATH` prepended by `./node_modules/.bin`, allowing you to run executables in your Node's dependencies.
+
+#### options.clearEnv
+
+type: `Boolean`
+
+default: false
+
+Whether to clear system environonment variables or not. If true, only those in options.env are used.

--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ type: `Boolean`
 
 default: false
 
-Whether to clear system environonment variables or not. If true, only those in options.env are used.
+Whether to clear the current environment or not before adding the variables in options.env.

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function shell(commands, options) {
 
   var env = clearEnv ? {} : _.defaults({PATH: PATH}, process.env);
 
-  if (options.env) {
+  if (options && options.env) {
     options.env = _.extend(env, options.env)
   }
 

--- a/index.js
+++ b/index.js
@@ -19,11 +19,19 @@ function shell(commands, options) {
   var pathToBin = path.join(process.cwd(), 'node_modules/.bin')
   var PATH = pathToBin + path.delimiter + process.env.PATH
 
+  var clearEnv = options.hasOwnProperty('clearEnv') ? options['clearEnv'] : false;
+
+  var env = clearEnv ? {} : _.defaults({PATH: PATH}, process.env);
+
+  if (options.env) {
+    options.env = _.extend(env, options.env)
+  }
+
   options = _.extend({
     ignoreErrors: false,
     quiet: false,
     cwd: process.cwd(),
-    env: _.defaults({PATH: PATH}, process.env),
+    env: env,
     maxBuffer: 16 * 1024 * 1024
   }, options)
 

--- a/index.js
+++ b/index.js
@@ -19,11 +19,18 @@ function shell(commands, options) {
   var pathToBin = path.join(process.cwd(), 'node_modules/.bin')
   var PATH = pathToBin + path.delimiter + process.env.PATH
 
-  var clearEnv = (options && options.hasOwnProperty('clearEnv')) ? options['clearEnv'] : false;
+  var clearEnv = false;
+  var env = _.defaults({PATH: PATH}, process.env);
 
-  var env = clearEnv ? {} : _.defaults({PATH: PATH}, process.env);
+  if (options) {
+    if (options.hasOwnProperty('clearEnv')) {
+      clearEnv = options.clearEnv;
+    }
 
-  if (options && options.env) {
+    if (clearEnv) {
+      env = {};
+    }
+
     options.env = _.extend(env, options.env)
   }
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function shell(commands, options) {
   var pathToBin = path.join(process.cwd(), 'node_modules/.bin')
   var PATH = pathToBin + path.delimiter + process.env.PATH
 
-  var clearEnv = options.hasOwnProperty('clearEnv') ? options['clearEnv'] : false;
+  var clearEnv = (options && options.hasOwnProperty('clearEnv')) ? options['clearEnv'] : false;
 
   var env = clearEnv ? {} : _.defaults({PATH: PATH}, process.env);
 


### PR DESCRIPTION
I think that env variables should be not cleared by default. I think many expect those to be present.

Since some uses cases may need it, I added an optional flag for it.