### PR TITLE
Add ability to have custom error messages on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ A command can be a [template][] which can be interpolated by some [file][] info 
 [template]: http://lodash.com/docs#template
 [file]:     https://github.com/wearefractal/vinyl
 
+#### options.errorMessage
+
+type: `String`
+
+You can add a custom error message for when the command fails.  This can be a [template][] which can be interpolated with some [file][] info (e.g. `file.path`) and some [error][] info (e.g. `error.code`).
+
+[error]: http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback
+
 #### options.ignoreErrors
 
 type: `Boolean`

--- a/index.js
+++ b/index.js
@@ -41,12 +41,12 @@ function shell(commands, options) {
         maxBuffer: options.maxBuffer
       }, function (error, stdout, stderr) {
         if (error && !options.ignoreErrors) {
+          error.stdout = stdout
+          error.stderr = stderr
           if (options.errorMessage) {
             var errorContext = _.extend({file: file, error: error}, options.templateData)
             error.message = gutil.template(options.errorMessage, errorContext)
           }
-          error.stdout = stdout
-          error.stderr = stderr
         }
 
         done(options.ignoreErrors ? null : error)

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ function shell(commands, options) {
 
   options = _.extend({
     ignoreErrors: false,
+    errorMessage: '',
     quiet: false,
     cwd: process.cwd(),
     maxBuffer: 16 * 1024 * 1024
@@ -40,6 +41,10 @@ function shell(commands, options) {
         maxBuffer: options.maxBuffer
       }, function (error, stdout, stderr) {
         if (error && !options.ignoreErrors) {
+          if (options.errorMessage) {
+            var errorContext = _.extend({file: file, error: error}, options.templateData)
+            error.message = gutil.template(options.errorMessage, errorContext)
+          }
           error.stdout = stdout
           error.stderr = stderr
         }

--- a/test/index.js
+++ b/test/index.js
@@ -110,35 +110,6 @@ describe('gulp-shell(commands, options)', function () {
     })
 
     describe('errorMessage', function () {
-      it('should override the default message', function (done) {
-        var errorMessage = 'Command failed: '
-        var changedMessage = 'foo'
-        var stream1 = shell(['false'])
-        var stream2 = shell(['false'], {errorMessage: changedMessage})
-        var otherStreamDone = false
-
-        function reallyDone () {
-          if (otherStreamDone) {
-            done()
-          } else {
-            otherStreamDone = true
-          }
-        }
-
-        stream1.on('error', function (error) {
-          error.message.should.equal(errorMessage)
-          reallyDone()
-        })
-
-        stream2.on('error', function (error) {
-          error.message.should.equal(changedMessage)
-          reallyDone()
-        })
-
-        stream1.write(fakeFile)
-        stream2.write(fakeFile)
-      })
-
       it('should allow for custom messages', function (done) {
         var errorMessage = 'foo'
         var stream = shell(['false'], {errorMessage: errorMessage})

--- a/test/index.js
+++ b/test/index.js
@@ -109,6 +109,62 @@ describe('gulp-shell(commands, options)', function () {
       })
     })
 
+    describe('errorMessage', function () {
+      it('should override the default message', function (done) {
+        var errorMessage = 'Command failed: '
+        var changedMessage = 'foo'
+        var stream1 = shell(['false'])
+        var stream2 = shell(['false'], {errorMessage: changedMessage})
+        var otherStreamDone = false
+
+        function reallyDone () {
+          if (otherStreamDone) {
+            done()
+          } else {
+            otherStreamDone = true
+          }
+        }
+
+        stream1.on('error', function (error) {
+          error.message.should.equal(errorMessage)
+          reallyDone()
+        })
+
+        stream2.on('error', function (error) {
+          error.message.should.equal(changedMessage)
+          reallyDone()
+        })
+
+        stream1.write(fakeFile)
+        stream2.write(fakeFile)
+      })
+
+      it('should allow for custom messages', function (done) {
+        var errorMessage = 'foo'
+        var stream = shell(['false'], {errorMessage: errorMessage})
+
+        stream.on('error', function (error) {
+          error.message.should.equal(errorMessage)
+          done()
+        })
+
+        stream.write(fakeFile)
+      })
+
+      it('should include the error object in the error context', function (done) {
+        var errorMessage = 'Foo <%= error.code %>'
+        var expectedMessage = 'Foo 2'
+        var stream = shell(['exit 2'], {errorMessage: errorMessage})
+
+        stream.on('error', function (error) {
+          error.message.should.equal(expectedMessage)
+          done()
+        })
+
+        stream.write(fakeFile)
+      })
+    })
+
     describe('cwd', function () {
       it('should set the current working directory when `cwd` is a string', function (done) {
         var stream = shell(['pwd'], {cwd: '..'})


### PR DESCRIPTION
Sometimes you'll want to have custom error messages (such as for use with `gulp-notify`).  This adds that feature.