### PR TITLE
add options.showErrorProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ default: `false`
 
 By default, it will print the command output.
 
+#### options.showErrorProperties
+
+type: `Boolean`
+
+default: `true`
+
+When the command exits with an error, a `new PluginError(pluginName, message[, options])` will be bubbled up to gulp. However, most command tools(e.g. `mocha`) have a self-sufficient logging system. The command itself will print the error, and then gulp will reprint that error again with a complex format.
+
+You can use `options` like this to bypass the complexity:
+
+    {
+        quiet: true,                             // turn off the cmd error logging
+        errorMessage: "\n<%= error.stdout %>",   // reprint the cmd error in the `Message` of the gulp plugin error logging
+        showErrorProperties: false               // turn off the `Detail` of the gulp plugin error logging
+    }
+
+`showErrorProperties` works as an alias of the `showProperties` option of gulp-utils `PluginError`.  For more information, checkout the [gulp-utils](https://github.com/gulpjs/gulp-util#new-pluginerrorpluginname-message-options).
+
 #### options.cwd
 
 type: `String`

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function shell(commands, options) {
     ignoreErrors: false,
     errorMessage: '',
     quiet: false,
+    showErrorProperties: true,
     cwd: process.cwd(),
     maxBuffer: 16 * 1024 * 1024
   }, options)
@@ -60,7 +61,8 @@ function shell(commands, options) {
       if (error) {
         self.emit('error', new gutil.PluginError(PLUGIN_NAME, error, {
           stdout: error.stdout,
-          stderr: error.stderr
+          stderr: error.stderr,
+          showProperties: options.showErrorProperties
         }))
       } else {
         self.push(file)

--- a/test/index.js
+++ b/test/index.js
@@ -109,6 +109,19 @@ describe('gulp-shell(commands, options)', function () {
       })
     })
 
+    describe('showErrorProperties', function () {
+      it('should bubble up the option `showErrorProperties` to gulp on error', function (done) {
+        var stream = shell(['false'], {showErrorProperties: false})
+
+        stream.on('error', function (pluginError) {
+          should(pluginError.showProperties).equal(false)
+          done()
+        })
+
+        stream.write(fakeFile)
+      })
+    })
+
     describe('errorMessage', function () {
       it('should allow for custom messages', function (done) {
         var errorMessage = 'foo'


### PR DESCRIPTION
When the command exits with an error, a `new PluginError(pluginName, message[, options])` will be bubbled up to gulp. However, most command tools(e.g. `mocha`) have a self-sufficient logging system. The command itself will print the error, and then gulp will reprint that error again with a complex format.

You can use `options` like this to bypass the complexity:

    {
        quiet: true, // turn off the cmd error logging
        errorMessage: "\n<%= error.stdout %>", // reprint the cmd error in the `Message` of the gulp plugin error logging
        showErrorProperties: false // turn off the `Detail` of the gulp plugin error logging
    }

`showErrorProperties` works as an alias of the `showProperties` option of gulp-utils `PluginError`. For more information, checkout the [gulp-utils](https://github.com/gulpjs/gulp-util#new-pluginerrorpluginname-message-options).