### PR TITLE
replace slashes according to platform, fix #50

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,9 +20,9 @@ gulp.task('watch', function () {
 })
 
 var isWin = /^win/.test(process.platform)
-var goodSlash = isWin ? '\\' : '/'
-var badSlash = isWin ? /\//g : /\\/g
-var slashCommand = './node_modules/.bin/gulp lint'.replace(badSlash, goodSlash)
+var badSlash = isWin ? '/' : '\\'
+var goodSlash = isWin ? /\\/g : /\//g
+var slashCommand = './node_modules/.bin/gulp lint'.replace(goodSlash, badSlash)
 
 gulp.task('slash-test', shell.task(
   slashCommand

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,3 +18,12 @@ gulp.task('default', ['coverage', 'lint'])
 gulp.task('watch', function () {
   gulp.watch(paths.js, ['default'])
 })
+
+var isWin = /^win/.test(process.platform)
+var goodSlash = isWin ? '\\' : '/'
+var badSlash = isWin ? /\//g : /\\/g
+var slashCommand = './node_modules/.bin/gulp lint'.replace(badSlash, goodSlash)
+
+gulp.task('slash-test', shell.task(
+  slashCommand
+))

--- a/index.js
+++ b/index.js
@@ -16,6 +16,14 @@ function shell(commands, options) {
     throw new gutil.PluginError(PLUGIN_NAME, 'Missing commands')
   }
 
+  var isWin = /^win/.test(process.platform)
+  var goodSlash = isWin ? '\\' : '/'
+  var badSlash = isWin ? /\//g : /\\/g
+
+  commands = commands.map(function (command) {
+    return command.replace(badSlash, goodSlash)
+  })
+
   options = _.extend({
     ignoreErrors: false,
     errorMessage: 'Command `<%= command %>` failed with exit code <%= error.code %>',


### PR DESCRIPTION
Replace slashes according to platform when task starts. If on windows, replace all `/` to `\`, otherwise replace all `\` to `/`.

Sorry that I'm not familiar with the test system, so I add a gulp task for simple testing. Just run `gulp slash-test`.

BTW, `gulp lint` fails on windows with or without this fix.

```
Error: ENOENT, no such file or directory 'C:\Users\eddie\projects\gulp-shell\*.js
```