### PR TITLE
Allow passing shell as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,15 @@ By default, all the commands will be executed in an environment with all the var
 You can override any environment variables with this option.
 
 For example, setting it to `{PATH: process.env.PATH}` will reset the `PATH` if the default one brings your some troubles.
+
+#### options.shell
+
+type: `String`
+
+String Shell to execute the command with (Default: '/bin/sh' on UNIX, 'cmd.exe' on Windows, The shell should understand the -c switch on UNIX or /s /c on Windows. Although, on windows environments with cygwin available you can set this to `bash` or `sh` and gulp-shell will invoke them with `-c` parameter instead.
+
+#### options.shellArgs
+
+type: `String`
+
+Additional parameters to pass to the shell prior to the command to execute (i.e. `/Q` in windows to turn the echo off or '--debug' in linux).

--- a/test/index.js
+++ b/test/index.js
@@ -103,6 +103,18 @@ describe('gulp-shell(commands, options)', function () {
 
         stream.write(fakeFile)
       })
+
+      it('prepends aditional arguments to `shell`', function (done) {
+        var stream = shell(['works'], {shellArgs: 'echo'})
+
+        stream.on('error', function () {
+          throw new Error()
+        })
+
+        expectToOutput('works', done)
+
+        stream.write(fakeFile)
+      })
     })
 
     describe('quiet', function () {


### PR DESCRIPTION
I find this useful because in some situations it might allow us, windows users to use a custom shell command to try to run cygwin 'sh'. I know this is not officially supported, but I guess adding the shell option to gulp-shell for us to play is harmless :-).

BTW, with this mod I've successfully executed the angular2 build pipeline (which uses bash scripts) completely in my windows machine.

Thanks!
