### PR TITLE
loosen lodash dependency (fixes #56)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "async": "~1.2.0",
     "gulp-util": "~3.0.5",
-    "lodash": "~3.9.3",
+    "lodash": "^3.9.3",
     "through2": "~0.6.5"
   }
 }


### PR DESCRIPTION
This allows for use of lodash 3.x.x (with a minimum of 3.9.3), instead of only lodash 3.9.x (min 3.9.3).