### PR TITLE
Add "verbose" option to print the command(s) being executed

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ A command can be a [template][] which can be interpolated by some [file][] info 
 [template]: http://lodash.com/docs#template
 [file]:     https://github.com/wearefractal/vinyl
 
+#### options.verbose
+
+type: `Boolean`
+
+default: `false`
+
+Set to `true` to print the command(s) to stdout as they are executed
+
 #### options.errorMessage
 
 type: `String`

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ function shell(commands, options) {
   }
 
   options = _.extend({
+    verbose: false,
     ignoreErrors: false,
     errorMessage: 'Command `<%= command %>` failed with exit code <%= error.code %>',
     quiet: false,
@@ -36,6 +37,10 @@ function shell(commands, options) {
     async.eachSeries(commands, function (command, done) {
       var context = _.extend({file: file}, options.templateData)
       command = gutil.template(command, context)
+
+      if (options.verbose) {
+        gutil.log(gutil.colors.blue(command))
+      }
 
       var child = exec(command, {
         env: options.env,


### PR DESCRIPTION
This is a change that I made on a fork because I sometimes find it useful to have gulp print out the command(s) being run by `shell` to the console, mainly for debugging purposes. I thought you might find it to be a useful addition to the tool, but if not, don't feel bad about rejecting the PR.

Also if you have any suggestions on how to do this better please let me know.

Thanks!