### PR TITLE
Drop dependency on deprecated gulp-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,13 @@
   },
   "dependencies": {
     "async": "^2.1.5",
-    "gulp-util": "^3.0.8",
+    "chalk": "^2.3.0",
+    "fancy-log": "^1.3.2",
     "lodash": "^4.17.4",
-    "through2": "^2.0.3"
+    "lodash.template": "^4.4.0",
+    "plugin-error": "^0.1.2",
+    "through2": "^2.0.3",
+    "vinyl": "^2.1.0"
   },
   "engines": {
     "node": ">=4.8.0 <5.0.0 || >=5.7.0"

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-const gutil = require('gulp-util')
+const Vinyl = require('vinyl')
 const join = require('path').join
 const expect = require('chai').expect
 
@@ -13,7 +13,7 @@ function expectToBeOk (stream, done) {
 }
 
 describe('gulp-shell(commands, options)', () => {
-  const fakeFile = new gutil.File({
+  const fakeFile = new Vinyl({
     cwd: __dirname,
     base: __dirname,
     path: join(__dirname, 'test-file')


### PR DESCRIPTION
Hello gulp-shell maintainers.

Following https://github.com/gulpjs/gulp-util/issues/143, I dropped dependency on gulp-util. 

closes #94

Thanks!