### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /node_modules/
 /npm-debug.log
 
-/coverage/
+.nyc_output/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,11 +7,11 @@ const paths = {
 
 gulp.task('test', shell.task('mocha'))
 
-gulp.task('coverage', shell.task('istanbul cover _mocha'))
+gulp.task('coverage', shell.task('nyc mocha'))
 
 gulp.task(
   'coveralls',
-  gulp.series('coverage', shell.task('cat coverage/lcov.info | coveralls'))
+  gulp.series('coverage', shell.task('nyc report --reporter=text-lcov | coveralls'))
 )
 
 gulp.task('lint', shell.task('standard ' + paths.js.join(' ')))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,18 +7,17 @@ const paths = {
 
 gulp.task('test', shell.task('mocha'))
 
-gulp.task('coverage', ['test'], shell.task('istanbul cover _mocha'))
+gulp.task('coverage', shell.task('istanbul cover _mocha'))
 
 gulp.task(
   'coveralls',
-  ['coverage'],
-  shell.task('cat coverage/lcov.info | coveralls')
+  gulp.series('coverage', shell.task('cat coverage/lcov.info | coveralls'))
 )
 
 gulp.task('lint', shell.task('standard ' + paths.js.join(' ')))
 
-gulp.task('default', ['coverage', 'lint'])
+gulp.task('default', gulp.parallel('coverage', 'lint'))
 
-gulp.task('watch', () => {
-  gulp.watch(paths.js, ['default'])
-})
+gulp.task('watch', gulp.series('default', function watch () {
+  gulp.watch(paths.js, gulp.task('default'))
+}))

--- a/index.js
+++ b/index.js
@@ -35,14 +35,14 @@ function normalizeOptions (options) {
   const pathToBin = path.join(process.cwd(), 'node_modules', '.bin')
   const pathName = /^win/.test(process.platform) ? 'Path' : 'PATH'
   const newPath = pathToBin + path.delimiter + process.env[pathName]
-  options.env = _.extend({}, process.env, {[pathName]: newPath}, options.env)
+  options.env = _.extend({}, process.env, { [pathName]: newPath }, options.env)
 
   return options
 }
 
 function runCommands (commands, options, file, done) {
   async.eachSeries(commands, (command, done) => {
-    const context = _.extend({file}, options.templateData)
+    const context = _.extend({ file }, options.templateData)
     command = template(command)(context)
 
     if (options.verbose) {
@@ -64,7 +64,7 @@ function runCommands (commands, options, file, done) {
       const context = _.extend({
         command,
         file,
-        error: {code}
+        error: { code }
       }, options.templateData)
 
       const message = template(options.errorMessage)(context)

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
   },
   "homepage": "https://github.com/sun-zheng-an/gulp-shell",
   "devDependencies": {
-    "chai": "^4.1.2",
-    "coveralls": "^3.0.0",
+    "chai": "^4.2.0",
+    "coveralls": "^3.0.2",
     "gulp": "^3.9.1",
     "istanbul": "^0.4.5",
-    "mocha": "^4.1.0",
+    "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.3.0",
     "standard": "^10.0.3",
-    "vinyl": "^2.1.0"
+    "vinyl": "^2.2.0"
   },
   "dependencies": {
     "async": "^2.1.5",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lodash": "^4.17.4",
     "lodash.template": "^4.4.0",
     "plugin-error": "^1.0.1",
-    "through2": "^2.0.3"
+    "through2": "^3.0.0"
   },
   "engines": {
     "node": ">=4.8.0 <5.0.0 || >=5.7.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.3.0",
-    "standard": "^10.0.3",
+    "standard": "^12.0.1",
     "vinyl": "^2.2.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "chai": "^4.2.0",
     "coveralls": "^3.0.2",
     "gulp": "^4.0.0",
-    "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.3.0",
+    "nyc": "^13.1.0",
     "standard": "^12.0.1",
     "vinyl": "^2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "fancy-log": "^1.3.2",
     "lodash": "^4.17.4",
     "lodash.template": "^4.4.0",
-    "plugin-error": "^0.1.2",
+    "plugin-error": "^1.0.1",
     "through2": "^2.0.3"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "coveralls": "^3.0.2",
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.0",
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.3.0",


### PR DESCRIPTION
Minor updates, except for gulp that I updated to v4.0.0, and istambul that was migrated to [nyc](https://github.com/istanbuljs/nyc).

Tests should pass. This also fixes all vulnerabilities reported by npm!

Anything relevant was added to the commit messages.